### PR TITLE
Handle scattered teams in data parser

### DIFF
--- a/gather.py
+++ b/gather.py
@@ -40,7 +40,9 @@ for season, starts in sorted(start_times.items()):
             team = team['data']
             if 'stadium' in team and team['stadium'] != None:
                 filtered_team = { field: team[field] for field in fields if field in team and team[field] != None }
-                teams[team['nickname']].append(filtered_team)
+                # Check scattered names first, then default
+                nickname = team.get('state', {}).get('scattered', {}).get('nickname', team['nickname'])
+                teams[nickname].append(filtered_team)
         idols = cache_chron_v2({'type': "idols", 'at':time2s(start), 'count':1})[0]
         noodle = idols['data']['data']['strictlyConfidential']
         noodles.append(noodle)


### PR DESCRIPTION
The unscattered team names are at `team.data.state.scattered.nickname`, which doesn't exist if they're unscattered. Default back to the team's nickname in the other case.